### PR TITLE
Compile on JDK8

### DIFF
--- a/client/src/main/java/com/oracle/graalvm/codeonline/build/PrepareClassPath.java
+++ b/client/src/main/java/com/oracle/graalvm/codeonline/build/PrepareClassPath.java
@@ -55,14 +55,25 @@ public final class PrepareClassPath {
 
     private static File getLibRtJar() {
         String javaHome = System.getProperty("java.home");
-        // use version 8 JDK, since newer JDKs do not seem to have lib/rt.jar
-        // TODO fix for newer JDKs and remove this
-        javaHome = "/usr/lib/jvm/java-8-openjdk";
-        File libRtJar = Paths.get(javaHome, "jre", "lib", "rt.jar").toFile();
-        if(libRtJar.exists())
-            return libRtJar;
-        else
-            return Paths.get(javaHome, "lib", "rt.jar").toFile();
+        File rtJar = findRtJar(javaHome);
+        if (rtJar == null) {
+            // try common Linux location
+            rtJar = findRtJar("/usr/lib/jvm/java-8-openjdk");
+        }
+        return rtJar;
+    }
+
+    private static File findRtJar(String javaHome) {
+        File libJreRtJar = Paths.get(javaHome, "jre", "lib", "rt.jar").toFile();
+        if(libJreRtJar.exists())
+            return libJreRtJar;
+        else {
+            File libRtJar = Paths.get(javaHome, "lib", "rt.jar").toFile();
+            if (libRtJar.exists()) {
+                return libRtJar;
+            }
+            return null;
+        }
     }
 
     private static void processPackages(File outDir, Location location, File inFile, Consumer<String> outputFileList) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
         <module>js</module>
     </modules>
     <properties>
-        <net.java.html.version>1.7</net.java.html.version>
+        <net.java.html.version>1.7.2</net.java.html.version>
         <openjfx.version>11</openjfx.version>
-        <bck2brwsr.version>0.32</bck2brwsr.version>
+        <bck2brwsr.version>0.51</bck2brwsr.version>
         <bck2brwsr.obfuscationlevel>MINIMAL</bck2brwsr.obfuscationlevel>
         <junit.browser.version>1.0</junit.browser.version>
         <jersey.version>2.13</jersey.version>


### PR DESCRIPTION
If running on JDK8, use the JDK's `rt.jar`. When running on JDK9+ fallback to well known location. Use [latest version of Bck2Brwsr](http://wiki.apidesign.org/wiki/Bck2Brwsr_0.51).

With these changes I can successfully compile the project on JDK8.