### PR TITLE
Separating compiler library into its own module

### DIFF
--- a/client-web/pom.xml
+++ b/client-web/pom.xml
@@ -194,6 +194,14 @@
             <scope>provided</scope>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.codeonline</groupId>
+            <artifactId>compiler</artifactId>
+            <version>${project.version}</version>
+            <classifier>bck2brwsr</classifier>
+            <scope>provided</scope>
+            <type>jar</type>
+        </dependency>
 
 
         <!-- browser JUnit runner -->

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -22,7 +22,6 @@
     <exec.java.bin>${java.home}/bin/java</exec.java.bin>
     <exec.debug.arg>-Ddebug=false</exec.debug.arg>
     <springloaded.javaagent>-Djavaagent=false</springloaded.javaagent>
-    <netbeans.version>RELEASE81</netbeans.version>
   </properties>
   <build>
       <plugins>
@@ -193,14 +192,9 @@
         <scope>provided</scope>
     </dependency>
     <dependency>
-        <groupId>org.netbeans.external</groupId>
-        <artifactId>nb-javac-impl</artifactId>
-        <version>${netbeans.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.netbeans.external</groupId>
-        <artifactId>nb-javac-api</artifactId>
-        <version>${netbeans.version}</version>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>compiler</artifactId>
+        <version>${project.version}</version>
     </dependency>
     <dependency>
         <groupId>org.ow2.asm</groupId>

--- a/javac/pom.xml
+++ b/javac/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+  http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.graalvm.codeonline</groupId>
+        <artifactId>codeonline-pom</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+ 
+    <artifactId>compiler</artifactId>
+    <packaging>bundle</packaging>
+ 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+ 
+    <repositories>
+      <repository>
+        <id>netbeans</id>
+        <name>NetBeans</name>
+        <url>http://bits.netbeans.org/maven2/</url>
+      </repository>
+    </repositories>
+ 
+    <dependencies>
+        <dependency>
+            <groupId>org.netbeans.external</groupId>
+            <artifactId>nb-javac-api</artifactId>
+            <version>${netbeans.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.external</groupId>
+            <artifactId>nb-javac-impl</artifactId>
+            <version>${netbeans.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+ 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <!-- export the packages that should be externally accessible -->
+                        <Export-Package>javax.*</Export-Package>
+                        <!-- list other packages that should be included in your bundle -->
+                        <Private-Package>com.sun.*</Private-Package>
+                    </instructions>
+                    <Embed-Dependency>*;scope=provided</Embed-Dependency>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apidesign.bck2brwsr</groupId>
+                <artifactId>bck2brwsr-maven-plugin</artifactId>
+                <version>${bck2brwsr.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>library</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <obfuscation>NONE</obfuscation>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <module>client</module>
         <module>client-web</module>
         <module>js</module>
+        <module>javac</module>
     </modules>
     <properties>
         <net.java.html.version>1.7.2</net.java.html.version>
@@ -23,6 +24,7 @@
         <jersey.version>2.13</jersey.version>
         <presenters.version>1.7.1</presenters.version>
         <enforcer.fail>false</enforcer.fail>
+        <netbeans.version>RELEASE81</netbeans.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
Implementing [OSGiWrapper](http://wiki.apidesign.org/wiki/OSGiWrapper) and [Bck2BrwsrLibraries](http://wiki.apidesign.org/wiki/Bck2BrwsrLibraries) advises to pretranspile the compiler module.

With this change we can speed the compilation of `client-web` module up. The idea is that compiler changes are rare, so it is not necessary to transpile it JavaScript again and again. Better to generate the transipiled code in the compiler module and then just extract it:
```
[INFO] --- bck2brwsr-maven-plugin:0.51:aot (default) @ codeonline-web ---
[INFO] Generating /codeonline/client-web/target/lib/codeonline-1.0-SNAPSHOT.js
[INFO] Extracting /codeonline/client-web/target/lib/net.java.html-1.7.2.js from /.m2/repository/org/apidesign/bck2brwsr/ko-bck2brwsr/0.51/ko-bck2brwsr-0.51-bck2brwsr.jar
[INFO] Extracting /codeonline/client-web/target/lib/net.java.html.json-1.7.2.js from /.m2/repository/org/apidesign/bck2brwsr/ko-bck2brwsr/0.51/ko-bck2brwsr-0.51-bck2brwsr.jar
[INFO] Extracting /codeonline/client-web/target/lib/net.java.html.sound-1.7.2.js from /.m2/repository/org/apidesign/bck2brwsr/ko-bck2brwsr/0.51/ko-bck2brwsr-0.51-bck2brwsr.jar
[INFO] Extracting /codeonline/client-web/target/lib/ko4j-1.7.2.js from /.m2/repository/org/apidesign/bck2brwsr/ko-bck2brwsr/0.51/ko-bck2brwsr-0.51-bck2brwsr.jar
[INFO] Extracting /codeonline/client-web/target/lib/codeonline-js-1.0-SNAPSHOT.js from /codeonline/js/target/codeonline-js-1.0-SNAPSHOT-bck2brwsr.jar

[INFO] Extracting /codeonline/client-web/target/lib/compiler-1.0-SNAPSHOT.js from /codeonline/javac/target/compiler-1.0-SNAPSHOT-bck2brwsr.jar

[INFO] Generating /codeonline/client-web/target/lib/asm-9.2.js
[INFO] Extracting /codeonline/client-web/target/lib/emul-0.51-rt.js from /.m2/repository/org/apidesign/bck2brwsr/emul/0.51/emul-0.51-bck2brwsr.jar
[INFO] Extracting /codeonline/client-web/target/lib/net.java.html.boot-1.7.2.js from /.m2/repository/org/apidesign/bck2brwsr/ko-bck2brwsr/0.51/ko-bck2brwsr-0.51-bck2brwsr.jar
[INFO] Generating /codeonline/client-web/target/lib/net.java.html.lib-0.5.js
[INFO] Generating /codeonline/client-web/target/lib/net.java.html.lib.dom-0.5.js
[INFO] Generating /codeonline/client-web/target/codeonline.js
```

Overall `mvn clean install` on the whole project is going to take as long as it does now, but when developing and working only on `client` and/or `client-web` the edit/compile/run cycle shall be faster.