### PR TITLE
Supporting building on JDK11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ codeonline$ mvn -f client-desktop -Pdesktop exec:exec
 ```
 
 The `exec:exec` command launches the project in JavaFX WebView emulator mode
-suitable for debugging Java code in the selected JDK. Use:
+suitable for debugging Java code in the selected JDK. Use...
 
 ```bash
 codeonline$ mvn -f client-desktop/ -Pdesktop exec:exec \
   -Dexec.debug.arg=-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=y
 ```
 
+...and connect your IDE to the `5005` port to track behavior of codeonline.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,23 @@
 
 ## Build and try it
 
-- (Clean and) Build Project `js`
-- Run Project `client`
+Building and running is JDK sensitive. One may need compatible JavaFX implementation,
+one may need compatible JavaScript implementation for the JVM. These components
+differ on OpenJDK, GraalVM, JDKs with JavaFX and between individual versions of
+the JDK. Switching between JDKs for each part of the build is an option, but
+to keep things simple let's start with JDK11 on Linux or Mac:
+
+```bash
+codeonline$ export JAVA_HOME=/jdk-11
+codeonline$ mvn clean install
+codeonline$ mvn -f client-desktop -Pdesktop exec:exec
+```
+
+The `exec:exec` command launches the project in JavaFX WebView emulator mode
+suitable for debugging Java code in the selected JDK. Use:
+
+```bash
+codeonline$ mvn -f client-desktop/ -Pdesktop exec:exec \
+  -Dexec.debug.arg=-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=y
+```
+

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -18,20 +18,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     
-    <build>
-        <plugins>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.3.2</version>
-              <configuration>
-                  <source>1.8</source>
-                  <target>1.8</target>
-              </configuration>
-          </plugin>
-        </plugins>
-    </build>
-    
     <dependencies>
         <dependency>
             <groupId>org.graalvm.codeonline</groupId>

--- a/client-desktop/pom.xml
+++ b/client-desktop/pom.xml
@@ -39,15 +39,6 @@
           </plugin>
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.3.2</version>
-              <configuration>
-                  <source>1.8</source>
-                  <target>1.8</target>
-              </configuration>
-          </plugin>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <version>2.19.1</version>
               <configuration>

--- a/client-desktop/pom.xml
+++ b/client-desktop/pom.xml
@@ -110,6 +110,61 @@
                   </execution>
               </executions>
           </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jar-plugin</artifactId>
+              <version>2.4</version>
+              <configuration>
+                  <archive>
+                      <manifest>
+                          <mainClass>${project.mainclass}</mainClass>
+                          <addClasspath>true</addClasspath>
+                          <classpathPrefix>lib/</classpathPrefix>
+                          <useUniqueVersions>false</useUniqueVersions>
+                      </manifest>
+                  </archive>
+              </configuration>
+          </plugin>
+          <plugin>
+              <artifactId>maven-assembly-plugin</artifactId>
+              <version>2.4</version>
+              <executions>
+                  <execution>
+                      <id>distro-assembly</id>
+                      <phase>package</phase>
+                      <goals>
+                          <goal>single</goal>
+                      </goals>
+                      <configuration>
+                          <descriptors>
+                              <descriptor>src/main/assembly/javafx.xml</descriptor>
+                          </descriptors>
+                      </configuration>
+                  </execution>
+              </executions>
+          </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-dependency-plugin</artifactId>
+              <version>2.9</version>
+              <executions>
+                  <execution>
+                      <id>unpack</id>
+                      <phase>process-resources</phase>
+                      <goals>
+                          <goal>unpack-dependencies</goal>
+                      </goals>
+                  </execution>
+              </executions>
+              <configuration>
+                  <type>zip</type>
+                  <classifier>webpages</classifier>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>target/classes/pages</outputDirectory>
+                  <includes>*/**</includes>
+                  <includeGroupIds>${project.groupId}</includeGroupIds>
+              </configuration>
+          </plugin>
       </plugins>
   </build>
     <repositories>
@@ -238,65 +293,6 @@
                   <scope>runtime</scope>
               </dependency>
           </dependencies>
-          <build>
-              <plugins>
-                  <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-jar-plugin</artifactId>
-                      <version>2.4</version>
-                      <configuration>
-                          <archive>
-                              <manifest>
-                                  <mainClass>${project.mainclass}</mainClass>
-                                  <addClasspath>true</addClasspath>
-                                  <classpathPrefix>lib/</classpathPrefix>
-                                  <useUniqueVersions>false</useUniqueVersions>
-                              </manifest>
-                          </archive>
-                      </configuration>
-                  </plugin>
-                  <plugin>
-                      <artifactId>maven-assembly-plugin</artifactId>
-                      <version>2.4</version>
-                      <executions>
-                          <execution>
-                              <id>distro-assembly</id>
-                              <phase>package</phase>
-                              <goals>
-                                  <goal>single</goal>
-                              </goals>
-                              <configuration>
-                                  <descriptors>
-                                      <descriptor>src/main/assembly/javafx.xml</descriptor>
-                                  </descriptors>
-                              </configuration>
-                          </execution>
-                      </executions>
-                  </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.9</version>
-                    <executions>
-                        <execution>
-                            <id>unpack</id>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>unpack-dependencies</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <type>zip</type>
-                        <classifier>webpages</classifier>
-                        <overWrite>true</overWrite>
-                        <outputDirectory>target/classes/pages</outputDirectory>
-                        <includes>*/**</includes>
-                        <includeGroupIds>${project.groupId}</includeGroupIds>
-                    </configuration>
-                </plugin>
-              </plugins>
-          </build>
       </profile>
       <profile>
           <id>webkit-presenter</id>

--- a/client-web/pom.xml
+++ b/client-web/pom.xml
@@ -45,15 +45,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -39,15 +39,6 @@
           </plugin>
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.3.2</version>
-              <configuration>
-                  <source>1.8</source>
-                  <target>1.8</target>
-              </configuration>
-          </plugin>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <version>2.19.1</version>
               <configuration>

--- a/compiler-common/pom.xml
+++ b/compiler-common/pom.xml
@@ -18,20 +18,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     
-    <build>
-        <plugins>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.3.2</version>
-              <configuration>
-                  <source>1.8</source>
-                  <target>1.8</target>
-              </configuration>
-          </plugin>
-        </plugins>
-    </build>
-    
     <dependencies>
         <dependency>
             <groupId>org.graalvm.codeonline</groupId>

--- a/compiler-nbjavac/pom.xml
+++ b/compiler-nbjavac/pom.xml
@@ -17,21 +17,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    
-    <build>
-        <plugins>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.3.2</version>
-              <configuration>
-                  <source>1.8</source>
-                  <target>1.8</target>
-              </configuration>
-          </plugin>
-        </plugins>
-    </build>
-    
     <dependencies>
         <dependency>
             <groupId>org.graalvm.codeonline</groupId>

--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -39,15 +39,6 @@
           </plugin>
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.3.2</version>
-              <configuration>
-                  <source>1.8</source>
-                  <target>1.8</target>
-              </configuration>
-          </plugin>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <version>2.19.1</version>
               <configuration>

--- a/js/pom.xml
+++ b/js/pom.xml
@@ -177,4 +177,28 @@
     </dependency>
     ... End of Bck2Brwsr VM presenter for BrowserRunner -->
   </dependencies>
+  <profiles>
+      <profile>
+          <id>explicit-js-engine</id>
+          <activation>
+              <jdk>[11,)</jdk>
+          </activation>
+          <build>
+              <plugins>
+                <plugin>
+                    <groupId>com.dukescript.libraries</groupId>
+                    <artifactId>typings-maven-plugin</artifactId>
+                    <version>0.5</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.openjdk.nashorn</groupId>
+                            <artifactId>nashorn-core</artifactId>
+                            <version>15.3</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+              </plugins>
+          </build>
+      </profile>
+  </profiles>
 </project>

--- a/js/pom.xml
+++ b/js/pom.xml
@@ -46,15 +46,6 @@
           </plugin>
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.3.2</version>
-              <configuration>
-                  <source>1.8</source>
-                  <target>1.8</target>
-              </configuration>
-          </plugin>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <version>2.19.1</version>
               <configuration>

--- a/models/pom.xml
+++ b/models/pom.xml
@@ -39,15 +39,6 @@
           </plugin>
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.3.2</version>
-              <configuration>
-                  <source>1.8</source>
-                  <target>1.8</target>
-              </configuration>
-          </plugin>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <version>2.19.1</version>
               <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,17 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.frgaal</groupId>
+                        <artifactId>compiler-maven-plugin</artifactId>
+                        <version>16.0.0</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <compilerId>frgaal</compilerId>
+                    <source>16</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
I have found a way to build on JDK11 and newer while preserving the capability to build on JDK8. One of the major benefit of JDK11 is that it always downloads JavaFX libraries from Maven central - e.g. it makes no difference if one is using OpenJDK or commercial JDK.

Yet we can still compile against JDK8 only APIs by setting the compiler target to `8`.

