### PR TITLE
Updating to support building on GraalVM8

### DIFF
--- a/compiler-common/pom.xml
+++ b/compiler-common/pom.xml
@@ -21,12 +21,12 @@
         <dependency>
             <groupId>com.dukescript.libraries</groupId>
             <artifactId>net.java.html.lib</artifactId>
-            <version>0.5</version>
+            <version>${typings.version}</version>
         </dependency>
         <dependency>
             <groupId>com.dukescript.libraries</groupId>
             <artifactId>net.java.html.lib.dom</artifactId>
-            <version>0.5</version>
+            <version>${typings.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -17,7 +17,7 @@
             <plugin>
                 <groupId>com.dukescript.libraries</groupId>
                 <artifactId>typings-maven-plugin</artifactId>
-                <version>0.5</version>
+                <version>${typings.version}</version>
                 <executions>
                     <execution>
                         <id>cm-typings</id>
@@ -46,12 +46,12 @@
         <dependency>
             <groupId>com.dukescript.libraries</groupId>
             <artifactId>net.java.html.lib</artifactId>
-            <version>0.5</version>
+            <version>${typings.version}</version>
         </dependency>
         <dependency>
             <groupId>com.dukescript.libraries</groupId>
             <artifactId>net.java.html.lib.dom</artifactId>
-            <version>0.5</version>
+            <version>${typings.version}</version>
         </dependency>
     </dependencies>
 
@@ -66,7 +66,7 @@
                     <plugin>
                         <groupId>com.dukescript.libraries</groupId>
                         <artifactId>typings-maven-plugin</artifactId>
-                        <version>0.5</version>
+                        <version>${typings.version}</version>
                         <dependencies>
                             <dependency>
                                 <groupId>org.openjdk.nashorn</groupId>

--- a/live-doc-test/pom.xml
+++ b/live-doc-test/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>org.apidesign.bck2brwsr</groupId>
                 <artifactId>bck2brwsr-maven-plugin</artifactId>
-                <version>0.51</version>
+                <version>0.52</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
 
     <properties>
         <net.java.html.version>1.7.2</net.java.html.version>
-        <bck2brwsr.version>0.51</bck2brwsr.version>
+        <bck2brwsr.version>0.52</bck2brwsr.version>
+        <typings.version>0.15</typings.version>
         <bck2brwsr.obfuscationlevel>MINIMAL</bck2brwsr.obfuscationlevel>
         <junit.browser.version>1.0</junit.browser.version>
         <enforcer.fail>false</enforcer.fail>


### PR DESCRIPTION
With these changes I am able to build (especially generate the Code Mirror typings) on `graalvm-ee-java8-21.2.0.1`.